### PR TITLE
fix typo of loaderVersion in forge versionRange

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -13,7 +13,7 @@ description='Experience Bug Fix.'
 [[dependencies.experiencebugfix]]
     modId="forge"
     mandatory=true
-loaderVersion="[41,)"
+    versionRange="[41,)"
     ordering="NONE"
     side="SERVER"
 


### PR DESCRIPTION
It appears `loaderVersion` was erroneously copied to the `versionRange` of forge a few commits back. This reverts the typo and keeps the version range the same.

Fixes #5